### PR TITLE
Add Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,4 +12,4 @@ blocks:
           commands:
             - sem-version go 1.13
             - checkout
-            - test -z (gofmt -l *.go)
+            - test -z $(gofmt -l *.go)

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,15 @@
+version: v1.0
+name: apartment-finder
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Lint
+    task:
+      jobs:
+        - name: gofmt
+          commands:
+            - sem-version go 1.13
+            - checkout
+            - test -z (gofmt -l *.go)


### PR DESCRIPTION
Adds a basic Semaphore CI configuration to lint with `gofmt`.