### PR TITLE
Add support for config via env vars

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,7 +37,7 @@ func (a *App) Init(configPath string, site string) error {
 	}
 
 	// load config from file
-	config, err := NewConfigFromYAML(configPath)
+	config, err := NewConfig(configPath)
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -3,36 +3,58 @@ package main
 import (
 	"os"
 
+	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v2"
 )
 
 // Config stores the application's configuration.
 type Config struct {
 	Twilio struct {
-		AccountSID string `yaml:"accountSid"`
-		AuthToken  string `yaml:"authToken"`
-		PhoneFrom  string `yaml:"phoneFrom"`
+		AccountSID string `yaml:"accountSid" envconfig:"TWILIO_ACCOUNT_SID"`
+		AuthToken  string `yaml:"authToken" envconfig:"TWILIO_AUTH_TOKEN"`
+		PhoneFrom  string `yaml:"phoneFrom" envconfig:"TWILIO_PHONE_FROM"`
 	} `yaml:"twilio"`
 	Bitly struct {
-		AccessToken string `yaml:"accessToken"`
+		AccessToken string `yaml:"accessToken" envconfig:"BITLY_ACCESS_TOKEN"`
 	} `yaml:"bitly"`
 	Notifications struct {
-		RecipientPhones []string `yaml:"recipientPhones"`
+		RecipientPhones []string `yaml:"recipientPhones" envconfig:"RECIPIENT_PHONES"`
 	} `yaml:"notifications"`
 }
 
-// NewConfigFromYAML initializes a new config from a YAML file.
-func NewConfigFromYAML(path string) (*Config, error) {
+func loadConfigFromYAML(c *Config, path string) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, ErrLoadingConfig
+		return ErrLoadingConfig
 	}
 
 	defer f.Close()
 
-	c := &Config{}
 	decoder := yaml.NewDecoder(f)
 	err = decoder.Decode(c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadConfigFromEnv(c *Config) error {
+	err := envconfig.Process("", c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewConfig initializes a new config from the given YAML file.
+// Environment variables can override the values in the file.
+func NewConfig(path string) (*Config, error) {
+	c := &Config{}
+
+	err := loadConfigFromYAML(c, path)
+	err = loadConfigFromEnv(c)
 	if err != nil {
 		return nil, ErrLoadingConfig
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/gocolly/colly/v2 v2.0.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	gopkg.in/yaml.v2 v2.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jawher/mow.cli v1.1.0 h1:NdtHXRc0CwZQ507wMvQ/IS+Q3W3x2fycn973/b8Zuk8=
 github.com/jawher/mow.cli v1.1.0/go.mod h1:aNaQlc7ozF3vw6IJ2dHjp2ZFiA4ozMIYY6PyuRJwlUg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
 github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Adds support for config via environment variables. These override any YAML config. This is required for deployment to Heroku.