### PR TITLE
Add Docker image

### DIFF
--- a/.semaphore/github-packages.yml
+++ b/.semaphore/github-packages.yml
@@ -1,0 +1,21 @@
+version: v1.0
+name: github-packages
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Build and push
+    task:
+      secrets:
+        - name: github-packages
+      prologue:
+        commands:
+          - echo "${GH_TOKEN}" | docker login docker.pkg.github.com -u "${GH_USER}" --password-stdin
+      jobs:
+        - name: build-and-push
+          commands:
+            - checkout --use-cache
+            - docker build -t "docker.pkg.github.com/bfogarty/apartment-finder/apartment-finder:${SEMAPHORE_GIT_SHA:0:7}" -t "docker.pkg.github.com/bfogarty/apartment-finder/apartment-finder:latest" .
+            - docker push "docker.pkg.github.com/bfogarty/apartment-finder/apartment-finder:${SEMAPHORE_GIT_SHA:0:7}"
+            - docker push "docker.pkg.github.com/bfogarty/apartment-finder/apartment-finder:latest"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,11 @@ blocks:
             - checkout
             - test -z $(gofmt -l *.go)
 promotions:
-    - name: Deploy Production
-      pipeline_file: heroku.yml
-      auto_promote:
-        when: "result = 'passed' and branch = 'master'"
+  - name: Release Package
+    pipeline_file: github-packages.yml
+    auto_promote:
+      when: "result = 'passed' and branch = 'master'"
+  - name: Deploy Production
+    pipeline_file: heroku.yml
+    auto_promote:
+      when: "result = 'passed' and branch = 'master'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:latest as build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -installsuffix 'static' -o /app .
+
+FROM scratch
+COPY --from=build /app /app
+USER 1000:1000
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
Adds a `Dockerfile` that:
- uses multistage builds to reduce the final image size
- fetches dependencies first to optimize for caching
- builds a statically-linked executable capable of running in the `scratch` image
- runs the executable as a non-privileged user in the `scratch` image

Adds CI steps to build and release the image to GitHub Packages tagging with `latest` and the commit SHA on each merge.